### PR TITLE
test 'Skip audio check' - clear default presentation toast or test ca…

### DIFF
--- a/bigbluebutton-tests/playwright/customparameters/customparameters.js
+++ b/bigbluebutton-tests/playwright/customparameters/customparameters.js
@@ -5,6 +5,7 @@ const c = require('./constants');
 const { VIDEO_LOADING_WAIT_TIME, ELEMENT_WAIT_LONGER_TIME } = require('../core/constants');
 const util = require('./util');
 const { getSettings } = require('../core/settings');
+const { waitAndClearDefaultPresentationNotification } = require('../notifications/util');
 
 class CustomParameters extends MultiUsers {
   constructor(browser, context) {
@@ -93,6 +94,7 @@ class CustomParameters extends MultiUsers {
   }
 
   async skipCheck() {
+    await waitAndClearDefaultPresentationNotification(this.modPage);
     await this.modPage.waitAndClick(e.microphoneButton);
     await this.modPage.waitForSelector(e.connecting);
     await this.modPage.wasRemoved(e.connecting, ELEMENT_WAIT_LONGER_TIME);


### PR DESCRIPTION
…n fail

because there'll be two small toasts at the end of this test